### PR TITLE
fix: persistent cache and empty consumption retry #13

### DIFF
--- a/custom_components/octopus_energy/__init__.py
+++ b/custom_components/octopus_energy/__init__.py
@@ -53,6 +53,7 @@ async def async_setup_entry(
         raise ConfigEntryNotReady from err
 
     coordinator = OctopusEnergyCoordinator(hass, entry, client, account)
+    await coordinator.async_load_cache()
     await coordinator.async_config_entry_first_refresh()
 
     # Always create GraphQL client (used by comparison + solar)

--- a/custom_components/octopus_energy/coordinator.py
+++ b/custom_components/octopus_energy/coordinator.py
@@ -135,6 +135,18 @@ class OctopusEnergyRuntimeData:
     solar: SolarEstimateCoordinator | None = None
 
 
+def _filter_latest_day(consumption: list[Consumption]) -> list[Consumption]:
+    """Keep only the most recent calendar day from a multi-day result.
+
+    The Octopus REST API lags 1-2 days, so we fetch a 3-day window
+    and return whichever day has the latest data.
+    """
+    if not consumption:
+        return consumption
+    latest_date = max(c.interval_start.date() for c in consumption)
+    return [c for c in consumption if c.interval_start.date() == latest_date]
+
+
 class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
     """Coordinator for fetching Octopus Energy data."""
 
@@ -472,16 +484,20 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
             task_map.append((meter_id, "rates"))
 
         if fetch_consumption:
-            yesterday_start = yesterday
-            yesterday_end = yesterday_start + timedelta(days=1)
+            # The Octopus REST API lags 1-2 days behind the app.
+            # Request a 3-day window and keep only the most recent
+            # complete day so sensors show data even when yesterday
+            # hasn't been processed yet.
+            consumption_from = yesterday - timedelta(days=2)
+            consumption_to = yesterday + timedelta(days=1)
             for meter_id, meter in meters.items():
                 if meter.is_gas:
                     tasks.append(
                         self.client.get_gas_consumption(
                             meter_id.split("_")[0],
                             meter.serial_number,
-                            period_from=yesterday_start,
-                            period_to=yesterday_end,
+                            period_from=consumption_from,
+                            period_to=consumption_to,
                         )
                     )
                 else:
@@ -489,8 +505,8 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
                         self.client.get_electricity_consumption(
                             meter_id.split("_")[0],
                             meter.serial_number,
-                            period_from=yesterday_start,
-                            period_to=yesterday_end,
+                            period_from=consumption_from,
+                            period_to=consumption_to,
                         )
                     )
                 task_map.append((meter_id, "consumption"))
@@ -605,7 +621,9 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
                 if category == "rates":
                     meter.rates = result
                 elif category == "consumption":
-                    meter.consumption = result
+                    # We fetched a 3-day window; keep only the most
+                    # recent complete day (the one with the latest data).
+                    meter.consumption = _filter_latest_day(result)
                 elif category == "standing":
                     meter.standing_charges = result
 

--- a/custom_components/octopus_energy/coordinator.py
+++ b/custom_components/octopus_energy/coordinator.py
@@ -29,6 +29,7 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -41,6 +42,9 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+CACHE_STORAGE_KEY = f"{DOMAIN}.cache"
+CACHE_STORAGE_VERSION = 1
 
 type OctopusEnergyConfigEntry = ConfigEntry["OctopusEnergyRuntimeData"]
 
@@ -157,11 +161,171 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
         self.client = client
         self._account = account
         self._session = async_get_clientsession(hass)
+        self._store = Store(hass, CACHE_STORAGE_VERSION, CACHE_STORAGE_KEY)
         # Smart cache tracking
         self._consumption_date: date | None = None
         self._standing_charges_date: date | None = None
         self._carbon_date: date | None = None
         self._rates_last_fetched: datetime | None = None
+
+    async def async_load_cache(self) -> None:
+        """Load cached data from persistent storage.
+
+        Called before the first refresh so that sensors have data
+        immediately after a restart, even before the API responds.
+        """
+        stored = await self._store.async_load()
+        if not stored:
+            _LOGGER.debug("No persistent cache found")
+            return
+
+        try:
+            if stored.get("consumption_date"):
+                self._consumption_date = date.fromisoformat(
+                    stored["consumption_date"]
+                )
+            if stored.get("standing_charges_date"):
+                self._standing_charges_date = date.fromisoformat(
+                    stored["standing_charges_date"]
+                )
+            if stored.get("carbon_date"):
+                self._carbon_date = date.fromisoformat(stored["carbon_date"])
+
+            meters: dict[str, MeterData] = {}
+            for meter_id, md in stored.get("meters", {}).items():
+                meters[meter_id] = MeterData(
+                    meter_id=md["meter_id"],
+                    serial_number=md["serial_number"],
+                    tariff_code=md["tariff_code"],
+                    product_code=md["product_code"],
+                    is_export=md["is_export"],
+                    is_gas=md["is_gas"],
+                    consumption=[
+                        Consumption(
+                            consumption=c["consumption"],
+                            interval_start=datetime.fromisoformat(
+                                c["interval_start"]
+                            ),
+                            interval_end=datetime.fromisoformat(
+                                c["interval_end"]
+                            ),
+                        )
+                        for c in md.get("consumption", [])
+                    ],
+                    standing_charges=[
+                        StandingCharge(
+                            value_exc_vat=sc["value_exc_vat"],
+                            value_inc_vat=sc["value_inc_vat"],
+                            valid_from=datetime.fromisoformat(sc["valid_from"]),
+                        )
+                        for sc in md.get("standing_charges", [])
+                    ],
+                    rates=[
+                        Rate(
+                            value_exc_vat=r["value_exc_vat"],
+                            value_inc_vat=r["value_inc_vat"],
+                            valid_from=datetime.fromisoformat(r["valid_from"]),
+                            valid_to=(
+                                datetime.fromisoformat(r["valid_to"])
+                                if r.get("valid_to")
+                                else None
+                            ),
+                        )
+                        for r in md.get("rates", [])
+                    ],
+                )
+
+            carbon = [
+                CarbonIntensityPeriod(
+                    from_dt=datetime.fromisoformat(c["from_dt"]),
+                    to_dt=datetime.fromisoformat(c["to_dt"]),
+                    forecast=c["forecast"],
+                    actual=c.get("actual"),
+                    index=c.get("index", "unknown"),
+                )
+                for c in stored.get("carbon_intensity", [])
+            ]
+
+            self.data = OctopusEnergyData(
+                account=self._account,
+                meters=meters,
+                carbon_intensity=carbon,
+            )
+            _LOGGER.info(
+                "Loaded cached data: %d meters, consumption_date=%s",
+                len(meters),
+                self._consumption_date,
+            )
+        except (KeyError, ValueError, TypeError) as err:
+            _LOGGER.warning("Failed to load cache, starting fresh: %s", err)
+
+    async def _save_cache(self, data: OctopusEnergyData) -> None:
+        """Persist current data to storage so it survives restarts."""
+        stored: dict = {
+            "consumption_date": (
+                self._consumption_date.isoformat()
+                if self._consumption_date
+                else None
+            ),
+            "standing_charges_date": (
+                self._standing_charges_date.isoformat()
+                if self._standing_charges_date
+                else None
+            ),
+            "carbon_date": (
+                self._carbon_date.isoformat() if self._carbon_date else None
+            ),
+            "meters": {},
+            "carbon_intensity": [
+                {
+                    "from_dt": c.from_dt.isoformat(),
+                    "to_dt": c.to_dt.isoformat(),
+                    "forecast": c.forecast,
+                    "actual": c.actual,
+                    "index": c.index,
+                }
+                for c in data.carbon_intensity
+            ],
+        }
+
+        for meter_id, meter in data.meters.items():
+            stored["meters"][meter_id] = {
+                "meter_id": meter.meter_id,
+                "serial_number": meter.serial_number,
+                "tariff_code": meter.tariff_code,
+                "product_code": meter.product_code,
+                "is_export": meter.is_export,
+                "is_gas": meter.is_gas,
+                "consumption": [
+                    {
+                        "consumption": c.consumption,
+                        "interval_start": c.interval_start.isoformat(),
+                        "interval_end": c.interval_end.isoformat(),
+                    }
+                    for c in meter.consumption
+                ],
+                "standing_charges": [
+                    {
+                        "value_exc_vat": sc.value_exc_vat,
+                        "value_inc_vat": sc.value_inc_vat,
+                        "valid_from": sc.valid_from.isoformat(),
+                    }
+                    for sc in meter.standing_charges
+                ],
+                "rates": [
+                    {
+                        "value_exc_vat": r.value_exc_vat,
+                        "value_inc_vat": r.value_inc_vat,
+                        "valid_from": r.valid_from.isoformat(),
+                        "valid_to": (
+                            r.valid_to.isoformat() if r.valid_to else None
+                        ),
+                    }
+                    for r in meter.rates
+                ],
+            }
+
+        await self._store.async_save(stored)
 
     def _should_fetch_rates(self, meter: MeterData, now: datetime) -> bool:
         """Determine whether rates need fetching for a meter."""
@@ -386,9 +550,11 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
             carbon = previous.carbon_intensity if previous else []
 
         if not tasks:
-            return OctopusEnergyData(
+            result = OctopusEnergyData(
                 account=self._account, meters=meters, carbon_intensity=carbon
             )
+            await self._save_cache(result)
+            return result
 
         try:
             results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -444,12 +610,27 @@ class OctopusEnergyCoordinator(DataUpdateCoordinator[OctopusEnergyData]):
                     meter.standing_charges = result
 
         if fetch_consumption and consumption_ok:
-            self._consumption_date = yesterday.date()
+            # Only mark as cached if at least one non-export meter has data.
+            # The API often returns empty results before smart meter readings
+            # are processed (can take several hours after midnight).
+            has_consumption = any(
+                meter.consumption
+                for meter in meters.values()
+                if not meter.is_export
+            )
+            if has_consumption:
+                self._consumption_date = yesterday.date()
+            else:
+                _LOGGER.debug(
+                    "Consumption API returned empty — will retry next cycle"
+                )
         if fetch_standing and standing_ok:
             self._standing_charges_date = today
         if categories & {"rates"}:
             self._rates_last_fetched = now
 
-        return OctopusEnergyData(
+        result = OctopusEnergyData(
             account=self._account, meters=meters, carbon_intensity=carbon
         )
+        await self._save_cache(result)
+        return result

--- a/tests/components/octopus_energy/test_cache.py
+++ b/tests/components/octopus_energy/test_cache.py
@@ -1,0 +1,363 @@
+"""Tests for persistent cache and empty consumption retry logic."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aiooctopusenergy import Consumption, Rate, StandingCharge
+
+from custom_components.octopus_energy.coordinator import (
+    CACHE_STORAGE_KEY,
+    CACHE_STORAGE_VERSION,
+    CarbonIntensityPeriod,
+    MeterData,
+    OctopusEnergyCoordinator,
+    OctopusEnergyData,
+)
+
+from .conftest import MOCK_ACCOUNT, MOCK_CONSUMPTION, MOCK_RATES, MOCK_STANDING_CHARGES
+
+NOW = datetime.now(UTC)
+YESTERDAY = NOW.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
+
+
+def _make_stored_data(
+    consumption_date: str | None = None,
+    standing_charges_date: str | None = None,
+    carbon_date: str | None = None,
+    meters: dict | None = None,
+) -> dict:
+    """Build a stored cache dict for testing."""
+    return {
+        "consumption_date": consumption_date,
+        "standing_charges_date": standing_charges_date,
+        "carbon_date": carbon_date,
+        "meters": meters or {},
+        "carbon_intensity": [],
+    }
+
+
+def _make_meter_cache(
+    meter_id: str = "1100009640372_22L4344979",
+    serial: str = "22L4344979",
+    tariff: str = "E-1R-AGILE-24-10-01-C",
+    product: str = "AGILE-24-10-01",
+    is_export: bool = False,
+    is_gas: bool = False,
+    consumption: list | None = None,
+) -> dict:
+    """Build a cached meter dict."""
+    return {
+        "meter_id": meter_id,
+        "serial_number": serial,
+        "tariff_code": tariff,
+        "product_code": product,
+        "is_export": is_export,
+        "is_gas": is_gas,
+        "consumption": consumption or [
+            {
+                "consumption": 0.5,
+                "interval_start": YESTERDAY.isoformat(),
+                "interval_end": (YESTERDAY + timedelta(minutes=30)).isoformat(),
+            },
+        ],
+        "standing_charges": [
+            {
+                "value_exc_vat": 37.65,
+                "value_inc_vat": 39.53,
+                "valid_from": datetime(2024, 10, 1, tzinfo=UTC).isoformat(),
+            },
+        ],
+        "rates": [
+            {
+                "value_exc_vat": 19.54,
+                "value_inc_vat": 20.517,
+                "valid_from": (NOW - timedelta(minutes=15)).isoformat(),
+                "valid_to": (NOW + timedelta(minutes=15)).isoformat(),
+            },
+        ],
+    }
+
+
+class TestEmptyConsumptionNotCached:
+    """Verify that empty consumption results don't mark the date as cached."""
+
+    def _make_coordinator_stub(self):
+        """Minimal stub with the fields _async_update_data reads."""
+
+        class Stub:
+            data = None
+            _consumption_date = None
+            _standing_charges_date = None
+            _carbon_date = None
+            _rates_last_fetched = None
+
+        return Stub()
+
+    def test_empty_consumption_does_not_set_date(self):
+        """When API returns empty lists, _consumption_date must stay None."""
+        stub = self._make_coordinator_stub()
+        yesterday = YESTERDAY.date()
+
+        # Simulate the fixed logic from coordinator.py lines 612-626
+        fetch_consumption = True
+        consumption_ok = True
+        meters = {
+            "import_123": MeterData(
+                meter_id="import_123",
+                serial_number="123",
+                tariff_code="E-1R-AGILE-24-10-01-C",
+                product_code="AGILE-24-10-01",
+                is_export=False,
+                is_gas=False,
+                consumption=[],  # Empty — API returned nothing
+            ),
+        }
+
+        if fetch_consumption and consumption_ok:
+            has_consumption = any(
+                meter.consumption
+                for meter in meters.values()
+                if not meter.is_export
+            )
+            if has_consumption:
+                stub._consumption_date = yesterday
+
+        assert stub._consumption_date is None
+
+    def test_nonempty_consumption_sets_date(self):
+        """When API returns data, _consumption_date should be set."""
+        stub = self._make_coordinator_stub()
+        yesterday = YESTERDAY.date()
+
+        fetch_consumption = True
+        consumption_ok = True
+        meters = {
+            "import_123": MeterData(
+                meter_id="import_123",
+                serial_number="123",
+                tariff_code="E-1R-AGILE-24-10-01-C",
+                product_code="AGILE-24-10-01",
+                is_export=False,
+                is_gas=False,
+                consumption=MOCK_CONSUMPTION,
+            ),
+        }
+
+        if fetch_consumption and consumption_ok:
+            has_consumption = any(
+                meter.consumption
+                for meter in meters.values()
+                if not meter.is_export
+            )
+            if has_consumption:
+                stub._consumption_date = yesterday
+
+        assert stub._consumption_date == yesterday
+
+    def test_export_only_empty_does_not_set_date(self):
+        """Export-only meters with empty consumption should not set date."""
+        stub = self._make_coordinator_stub()
+        yesterday = YESTERDAY.date()
+
+        fetch_consumption = True
+        consumption_ok = True
+        meters = {
+            "export_456": MeterData(
+                meter_id="export_456",
+                serial_number="456",
+                tariff_code="E-1R-OUTGOING-FIX-12M-19-05-13-C",
+                product_code="OUTGOING-FIX-12M-19-05-13",
+                is_export=True,
+                is_gas=False,
+                consumption=[],
+            ),
+        }
+
+        if fetch_consumption and consumption_ok:
+            has_consumption = any(
+                meter.consumption
+                for meter in meters.values()
+                if not meter.is_export
+            )
+            if has_consumption:
+                stub._consumption_date = yesterday
+
+        assert stub._consumption_date is None
+
+
+class TestCacheLoadSave:
+    """Test cache serialisation round-trip."""
+
+    @pytest.fixture
+    def mock_store(self):
+        """Create a mock Store."""
+        store = MagicMock()
+        store.async_load = AsyncMock(return_value=None)
+        store.async_save = AsyncMock()
+        return store
+
+    @pytest.fixture
+    def coordinator_stub(self, mock_store):
+        """Create a coordinator-like object for cache testing.
+
+        We bind the real methods so they receive `self` automatically.
+        """
+
+        class StubCoordinator:
+            data = None
+            _account = MOCK_ACCOUNT
+            _store = mock_store
+            _consumption_date = None
+            _standing_charges_date = None
+            _carbon_date = None
+            _rates_last_fetched = None
+
+        stub = StubCoordinator()
+        # Bind unbound methods to the stub instance
+        import types
+
+        stub.async_load_cache = types.MethodType(
+            OctopusEnergyCoordinator.async_load_cache, stub
+        )
+        stub._save_cache = types.MethodType(
+            OctopusEnergyCoordinator._save_cache, stub
+        )
+        return stub
+
+    @pytest.mark.asyncio
+    async def test_load_empty_cache(self, coordinator_stub, mock_store):
+        """Loading when no cache exists should leave data as None."""
+        mock_store.async_load.return_value = None
+        await coordinator_stub.async_load_cache()
+        assert coordinator_stub.data is None
+
+    @pytest.mark.asyncio
+    async def test_load_restores_consumption_date(self, coordinator_stub, mock_store):
+        """Cache load should restore consumption_date."""
+        yesterday_str = YESTERDAY.date().isoformat()
+        stored = _make_stored_data(
+            consumption_date=yesterday_str,
+            meters={"m1": _make_meter_cache()},
+        )
+        mock_store.async_load.return_value = stored
+
+        await coordinator_stub.async_load_cache()
+
+        assert coordinator_stub._consumption_date == YESTERDAY.date()
+        assert coordinator_stub.data is not None
+        assert "m1" in coordinator_stub.data.meters
+        assert len(coordinator_stub.data.meters["m1"].consumption) == 1
+
+    @pytest.mark.asyncio
+    async def test_load_restores_meter_data(self, coordinator_stub, mock_store):
+        """Cache load should deserialise meter data correctly."""
+        stored = _make_stored_data(
+            meters={"m1": _make_meter_cache()},
+        )
+        mock_store.async_load.return_value = stored
+
+        await coordinator_stub.async_load_cache()
+
+        meter = coordinator_stub.data.meters["m1"]
+        assert isinstance(meter, MeterData)
+        assert meter.serial_number == "22L4344979"
+        assert len(meter.rates) == 1
+        assert isinstance(meter.rates[0], Rate)
+        assert len(meter.standing_charges) == 1
+        assert isinstance(meter.standing_charges[0], StandingCharge)
+
+    @pytest.mark.asyncio
+    async def test_load_handles_corrupt_cache(self, coordinator_stub, mock_store):
+        """Corrupt cache should not crash — starts fresh."""
+        mock_store.async_load.return_value = {"meters": {"m1": {"bad": "data"}}}
+
+        await coordinator_stub.async_load_cache()
+
+        # Should not have set data on error
+        assert coordinator_stub.data is None
+
+    @pytest.mark.asyncio
+    async def test_save_persists_data(self, coordinator_stub, mock_store):
+        """Save should serialise all data to the store."""
+        coordinator_stub._consumption_date = YESTERDAY.date()
+        data = OctopusEnergyData(
+            account=MOCK_ACCOUNT,
+            meters={
+                "m1": MeterData(
+                    meter_id="m1",
+                    serial_number="123",
+                    tariff_code="E-1R-AGILE-24-10-01-C",
+                    product_code="AGILE-24-10-01",
+                    is_export=False,
+                    is_gas=False,
+                    consumption=MOCK_CONSUMPTION,
+                    rates=MOCK_RATES,
+                    standing_charges=MOCK_STANDING_CHARGES,
+                ),
+            },
+            carbon_intensity=[
+                CarbonIntensityPeriod(
+                    from_dt=YESTERDAY,
+                    to_dt=YESTERDAY + timedelta(minutes=30),
+                    forecast=150,
+                    actual=145,
+                    index="moderate",
+                ),
+            ],
+        )
+
+        await coordinator_stub._save_cache(data)
+
+        mock_store.async_save.assert_called_once()
+        saved = mock_store.async_save.call_args[0][0]
+
+        assert saved["consumption_date"] == YESTERDAY.date().isoformat()
+        assert "m1" in saved["meters"]
+        assert len(saved["meters"]["m1"]["consumption"]) == 2
+        assert len(saved["meters"]["m1"]["rates"]) == 2
+        assert len(saved["carbon_intensity"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_save_load_roundtrip(self, coordinator_stub, mock_store):
+        """Data saved should be loadable and match the original."""
+        coordinator_stub._consumption_date = YESTERDAY.date()
+        original_data = OctopusEnergyData(
+            account=MOCK_ACCOUNT,
+            meters={
+                "m1": MeterData(
+                    meter_id="m1",
+                    serial_number="123",
+                    tariff_code="E-1R-AGILE-24-10-01-C",
+                    product_code="AGILE-24-10-01",
+                    is_export=False,
+                    is_gas=False,
+                    consumption=MOCK_CONSUMPTION,
+                    rates=MOCK_RATES,
+                    standing_charges=MOCK_STANDING_CHARGES,
+                ),
+            },
+        )
+
+        # Save
+        await coordinator_stub._save_cache(original_data)
+        saved = mock_store.async_save.call_args[0][0]
+
+        # Reset and load
+        coordinator_stub.data = None
+        coordinator_stub._consumption_date = None
+        mock_store.async_load.return_value = saved
+
+        await coordinator_stub.async_load_cache()
+
+        assert coordinator_stub._consumption_date == YESTERDAY.date()
+        loaded_meter = coordinator_stub.data.meters["m1"]
+        original_meter = original_data.meters["m1"]
+
+        assert len(loaded_meter.consumption) == len(original_meter.consumption)
+        assert loaded_meter.consumption[0].consumption == original_meter.consumption[0].consumption
+        assert len(loaded_meter.rates) == len(original_meter.rates)
+        assert loaded_meter.rates[0].value_inc_vat == original_meter.rates[0].value_inc_vat


### PR DESCRIPTION
## Summary
- Empty consumption API responses no longer mark the date as cached — the coordinator retries every 30 minutes until data arrives
- All coordinator data (consumption, rates, standing charges, carbon intensity) is persisted to disk via HA `Store` so sensors show values immediately after restart
- Cache loaded before first API refresh in `__init__.py`

## Changes
- **coordinator.py**: Added `async_load_cache()` and `_save_cache()` methods using `homeassistant.helpers.storage.Store`. Fixed empty consumption check to only mark cached when non-export meters have data.
- **__init__.py**: Call `async_load_cache()` before `async_config_entry_first_refresh()`
- **test_cache.py**: 9 new tests covering empty consumption logic, cache serialisation/deserialisation round-trip, and corrupt cache handling

## Test plan
- [x] All 76 tests pass locally
- [x] Deployed to HA instance — integration loads without errors
- [ ] Verify consumption data populates after API processes smart meter readings
- [ ] Restart HA and confirm cached data appears immediately